### PR TITLE
Fix duplicate identifier bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Nothing
 
+## [0.3.2] - 2022-04-02
+### Fix
+- Fix bug when duplicate identifier is exists in `dyn css!`.
+
 ## [0.3.1] - 2022-03-27
 ### Fix
 - Fix documentation.
@@ -27,6 +31,7 @@ Nothing
 ### Added
 - Initial release.
 
+[0.3.2]: https://github.com/MatchaChoco010/yew-style-in-rs/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/MatchaChoco010/yew-style-in-rs/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/MatchaChoco010/yew-style-in-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/MatchaChoco010/yew-style-in-rs/compare/v0.1.0...v0.2.0

--- a/packages/yew-style-in-rs-core/Cargo.toml
+++ b/packages/yew-style-in-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-style-in-rs-core"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Orito Itsuki <orito.itsuki@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/packages/yew-style-in-rs-macro/Cargo.toml
+++ b/packages/yew-style-in-rs-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-style-in-rs-macro"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Orito Itsuki <orito.itsuki@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -24,4 +24,4 @@ quote = "1.0.15"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 syn = { version = "1.0.86", features = ["full"] }
-yew-style-in-rs-core = { version = "0.3.0", path = "../yew-style-in-rs-core" }
+yew-style-in-rs-core = { version = "0.3.2", path = "../yew-style-in-rs-core" }

--- a/packages/yew-style-in-rs-macro/src/style/dyn_css.rs
+++ b/packages/yew-style-in-rs-macro/src/style/dyn_css.rs
@@ -1,5 +1,6 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{quote, TokenStreamExt};
+use std::collections::HashSet;
 
 use crate::cursor::*;
 use crate::style::keyframes::*;
@@ -82,7 +83,12 @@ impl DynCss {
 
         let dependencies = {
             let mut dependencies = TokenStream::new();
+            let mut hashset = HashSet::new();
             for ident in &self.idents {
+                hashset.insert(ident.to_string());
+            }
+            for ident in hashset.iter() {
+                let ident = syn::Ident::new(ident, Span::call_site());
                 dependencies.append_all(quote!(#ident = #ident, ));
             }
             dependencies

--- a/packages/yew-style-in-rs-macro/src/style/dyn_keyframes.rs
+++ b/packages/yew-style-in-rs-macro/src/style/dyn_keyframes.rs
@@ -1,5 +1,6 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{quote, TokenStreamExt};
+use std::collections::HashSet;
 
 use crate::cursor::*;
 
@@ -127,7 +128,12 @@ impl DynKeyframes {
 
         let dependencies = {
             let mut dependencies = TokenStream::new();
+            let mut hashset = HashSet::new();
             for ident in &idents {
+                hashset.insert(ident.to_string());
+            }
+            for ident in hashset.iter() {
+                let ident = syn::Ident::new(ident, Span::call_site());
                 dependencies.append_all(quote!(#ident = #ident, ));
             }
             dependencies

--- a/packages/yew-style-in-rs/Cargo.toml
+++ b/packages/yew-style-in-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-style-in-rs"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Orito Itsuki <orito.itsuki@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -21,5 +21,5 @@ web-sys = { version = "0.3.56", features = [
     "HtmlStyleElement",
 ]}
 yew = "0.19.3"
-yew-style-in-rs-core = { version = "0.3.0", path = "../yew-style-in-rs-core" }
-yew-style-in-rs-macro = { version = "0.3.0", path = "../yew-style-in-rs-macro" }
+yew-style-in-rs-core = { version = "0.3.2", path = "../yew-style-in-rs-core" }
+yew-style-in-rs-macro = { version = "0.3.2", path = "../yew-style-in-rs-macro" }


### PR DESCRIPTION
Fix bug when identifier in the `${identifier}` of `dyn css!` and `dyn keyframes` are duplicated.
The format argument needed to be unique.