### PR TITLE
Fix `dry-run` not write Cargo.lock file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2022-06-05
+### Fix
+- Fix `dry-run` not write Cargo.lock file.
+
 ## [0.4.0] - 2022-06-04
 ### Fix
 - Corrected the wording of the Apache 2.0 License.
@@ -37,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[0.4.1]: https://github.com/MatchaChoco010/yew-style-in-rs/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/MatchaChoco010/yew-style-in-rs/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/MatchaChoco010/yew-style-in-rs/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/MatchaChoco010/yew-style-in-rs/compare/v0.3.0...v0.3.1

--- a/packages/yew-style-in-rs-core/Cargo.toml
+++ b/packages/yew-style-in-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-style-in-rs-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["ORITO Itsuki <orito.itsuki@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/packages/yew-style-in-rs-macro/Cargo.toml
+++ b/packages/yew-style-in-rs-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-style-in-rs-macro"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["ORITO Itsuki <orito.itsuki@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -25,4 +25,4 @@ quote = "1.0.15"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 syn = { version = "1.0.86", features = ["full"] }
-yew-style-in-rs-core = { version = "0.4.0", path = "../yew-style-in-rs-core" }
+yew-style-in-rs-core = { version = "0.4.1", path = "../yew-style-in-rs-core" }

--- a/packages/yew-style-in-rs-macro/src/lib.rs
+++ b/packages/yew-style-in-rs-macro/src/lib.rs
@@ -12,7 +12,7 @@ pub fn style_with_write(tokens: TokenStream) -> TokenStream {
     {
         use crate::state::*;
         let mut state = STATE.lock().unwrap();
-        state.write_flag = true;
+        state.set_write_flag(true);
     }
 
     // expand macro
@@ -27,7 +27,7 @@ pub fn style_without_write(tokens: TokenStream) -> TokenStream {
     {
         use crate::state::*;
         let mut state = STATE.lock().unwrap();
-        state.write_flag = false;
+        state.set_write_flag(false);
     }
 
     // expand macro

--- a/packages/yew-style-in-rs-macro/src/style/css.rs
+++ b/packages/yew-style-in-rs-macro/src/style/css.rs
@@ -68,7 +68,7 @@ impl Css {
 
         let mut state = STATE.lock().unwrap();
 
-        let id = if state.write_flag {
+        let id = if state.write_flag() {
             let (id, mut file) = state
                 .create_random_id_file()
                 .expect("Failed to save internal file for yew-style-in-rs");

--- a/packages/yew-style-in-rs-macro/src/style/keyframes.rs
+++ b/packages/yew-style-in-rs-macro/src/style/keyframes.rs
@@ -80,7 +80,7 @@ impl Keyframes {
 
         let mut state = STATE.lock().unwrap();
 
-        let anim_names = if state.write_flag {
+        let anim_names = if state.write_flag() {
             let (id, mut file) = state
                 .create_random_id_file()
                 .expect("Failed to save internal file for yew-style-in-rs");

--- a/packages/yew-style-in-rs-macro/src/util.rs
+++ b/packages/yew-style-in-rs-macro/src/util.rs
@@ -33,6 +33,8 @@ pub fn is_release() -> bool {
 // Get the directory from which the last directory was removed from the `--out-dir` argument
 // as a workaround.
 // if there is no `--out-dir` argument, then use default directory for `workspace/target/{profile}`.
+//
+// This method create Cargo.lock file if not exists, so this method should not call when dry-run.
 pub fn get_out_dir() -> PathBuf {
     let profile = if is_release() { "release" } else { "debug" };
 
@@ -60,6 +62,8 @@ pub fn get_out_dir() -> PathBuf {
 //
 // Currently rust workspace directory information is only in `cargo metadata`.
 // So execute `cargo metadata` and parse json to get workspace_root directory.
+//
+// This method create Cargo.lock file if not exists, so this method should not call when dry-run.
 pub fn get_cargo_workspace() -> PathBuf {
     WORKSPACE
         .get_or_init(|| {
@@ -88,6 +92,8 @@ pub fn get_cargo_workspace() -> PathBuf {
 //
 // `cargo metadata` return dependencies information/
 // So execute `cargo metadata` and parse json to get dependencies name.
+//
+// This method create Cargo.lock file if not exists, so this method should not call when dry-run.
 pub fn get_cargo_packages() -> Vec<String> {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let output = std::process::Command::new(env::var("CARGO").unwrap())

--- a/packages/yew-style-in-rs/Cargo.toml
+++ b/packages/yew-style-in-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-style-in-rs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["ORITO Itsuki <orito.itsuki@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -30,5 +30,5 @@ web-sys = { version = "0.3.56", features = [
     "HtmlStyleElement",
 ]}
 yew = "0.19.3"
-yew-style-in-rs-core = { version = "0.4.0", path = "../yew-style-in-rs-core" }
-yew-style-in-rs-macro = { version = "0.4.0", path = "../yew-style-in-rs-macro" }
+yew-style-in-rs-core = { version = "0.4.1", path = "../yew-style-in-rs-core" }
+yew-style-in-rs-macro = { version = "0.4.1", path = "../yew-style-in-rs-macro" }


### PR DESCRIPTION
`cargo metadata`, which called in macro, create `Cargo.lock` file and this cause error when publishing crate depends with yew-style-in-rs.